### PR TITLE
feat: bootstrap telemetry API and UI scaffolding

### DIFF
--- a/kitsu-telemetry/.env.example
+++ b/kitsu-telemetry/.env.example
@@ -1,0 +1,5 @@
+# Caminho para o banco SQLite da telemetria
+TELEMETRY_DB_PATH=./data/telemetry.db
+
+# Porta padrão para a API FastAPI
+API_PORT=8001

--- a/kitsu-telemetry/AGENTS.md
+++ b/kitsu-telemetry/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Escopo
+Arquivos neste diretório descrevem a API e UI de telemetria do projeto Kitsu.exe. Siga as diretrizes abaixo ao modificar qualquer arquivo sob `kitsu-telemetry/`.
+
+## Estilo geral
+- Prefira código assíncrono e digitado (type hints explícitos em Python e TypeScript).
+- Utilize nomes autoexplicativos e comentários curtos apenas quando necessário.
+- Mantenha a documentação em português.
+
+## Backend (Python)
+- Use FastAPI com rotas claras (`/health`, `/events`, `/events/export`).
+- Persistência via SQLite usando `aiosqlite`; inicialize a base na inicialização do app.
+- Exporte CSV em streaming (`text/csv`) para evitar carregar tudo em memória.
+
+## Frontend (SvelteKit)
+- UI baseada em Tailwind CSS.
+- Crie componentes acessíveis (atributos `aria-*` quando fizer sentido).
+- Mock de WebSocket deve permitir testes locais sem backend em tempo real.
+
+## Testes
+- Garanta que os testes possam rodar com `pytest -q` na raiz do repositório.
+- Inclua smoke tests para a importação do app pelo Uvicorn e para a exportação CSV.

--- a/kitsu-telemetry/README.md
+++ b/kitsu-telemetry/README.md
@@ -1,0 +1,37 @@
+# Kitsu Telemetry
+
+Módulo de telemetria para o ecossistema Kitsu.exe, composto por uma API FastAPI e uma interface SvelteKit com Tailwind CSS.
+
+## Pré-requisitos
+- Python 3.11+
+- Poetry ou `pip` para instalar dependências
+- Node.js 18+ com `pnpm`
+
+## Configuração rápida
+1. Copie `.env.example` para `.env` e ajuste as variáveis conforme necessário.
+2. Instale as dependências Python:
+   ```bash
+   poetry install
+   ```
+3. Inicialize a UI:
+   ```bash
+   cd kitsu-telemetry/ui
+   pnpm install
+   pnpm dev
+   ```
+
+## Executando a API
+```bash
+uvicorn api.main:app --reload --port ${API_PORT:-8001}
+```
+
+## Estrutura
+- `api/`: código da API de telemetria (FastAPI + SQLite).
+- `ui/`: front-end SvelteKit com Tailwind e mock de WebSocket para prototipagem.
+- `tests/`: testes de fumaça para endpoints e exportação CSV.
+
+## Testes
+Execute na raiz do repositório:
+```bash
+pytest -q
+```

--- a/kitsu-telemetry/api/main.py
+++ b/kitsu-telemetry/api/main.py
@@ -1,0 +1,83 @@
+"""Aplicação FastAPI responsável pela telemetria."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any
+
+from fastapi import FastAPI, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from . import storage
+
+
+class TelemetryIn(BaseModel):
+    source: str = Field(..., description="Origem do evento (ex.: obs, bot)")
+    event_type: str = Field(..., description="Tipo do evento (ex.: frame, emotion)")
+    payload: dict[str, Any] = Field(default_factory=dict, description="Dados associados")
+
+
+class TelemetryOut(TelemetryIn):
+    created_at: datetime | None = Field(None, description="Timestamp de criação")
+
+    @classmethod
+    def from_storage(cls, event: storage.TelemetryEvent) -> "TelemetryOut":
+        created_at: datetime | None = None
+        if event.created_at:
+            try:
+                created_at = datetime.fromisoformat(event.created_at)
+            except ValueError:
+                created_at = None
+        return cls(
+            source=event.source,
+            event_type=event.event_type,
+            payload=event.payload,
+            created_at=created_at,
+        )
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    await storage.init_db()
+    yield
+
+
+app = FastAPI(title="Kitsu Telemetry API", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/events", response_model=dict[str, int])
+async def ingest_event(event: TelemetryIn) -> dict[str, int]:
+    telemetry = storage.TelemetryEvent(
+        source=event.source,
+        event_type=event.event_type,
+        payload=event.payload,
+    )
+    event_id = await storage.insert_event(telemetry)
+    return {"id": event_id}
+
+
+@app.get("/events", response_model=list[TelemetryOut])
+async def get_events(
+    *,
+    limit: int | None = Query(None, ge=1, le=500),
+    event_type: str | None = None,
+    source: str | None = None,
+) -> list[TelemetryOut]:
+    events = await storage.list_events(limit=limit, event_type=event_type, source=source)
+    return [TelemetryOut.from_storage(event) for event in events]
+
+
+@app.get("/events/export")
+async def export_events() -> StreamingResponse:
+    async def csv_generator():
+        async for chunk in storage.stream_events_as_csv():
+            yield chunk
+
+    headers = {"Content-Disposition": "attachment; filename=telemetry_events.csv"}
+    return StreamingResponse(csv_generator(), media_type="text/csv", headers=headers)

--- a/kitsu-telemetry/api/storage.py
+++ b/kitsu-telemetry/api/storage.py
@@ -1,0 +1,159 @@
+"""Camada de persistência da telemetria."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncIterator, Sequence
+
+import aiosqlite
+
+_DB_ENV_VAR = "TELEMETRY_DB_PATH"
+_DEFAULT_DB_PATH = "telemetry.db"
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    """Representa um evento recebido pela API de telemetria."""
+
+    source: str
+    event_type: str
+    payload: dict[str, Any]
+    created_at: str | None = None
+
+
+def _resolve_db_path(db_path: str | None = None) -> str:
+    path = Path(db_path or os.getenv(_DB_ENV_VAR, _DEFAULT_DB_PATH))
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
+async def init_db(db_path: str | None = None) -> None:
+    """Garante que a tabela de eventos exista."""
+
+    database_path = _resolve_db_path(db_path)
+    async with aiosqlite.connect(database_path) as conn:
+        await conn.execute("PRAGMA journal_mode=WAL;")
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS telemetry_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await conn.commit()
+
+
+async def insert_event(event: TelemetryEvent, db_path: str | None = None) -> int:
+    """Insere um evento na base e retorna o ID criado."""
+
+    database_path = _resolve_db_path(db_path)
+    async with aiosqlite.connect(database_path) as conn:
+        cursor = await conn.execute(
+            """
+            INSERT INTO telemetry_events (source, event_type, payload)
+            VALUES (?, ?, ?)
+            """,
+            (event.source, event.event_type, json.dumps(event.payload, ensure_ascii=False)),
+        )
+        await conn.commit()
+        return cursor.lastrowid
+
+
+async def list_events(
+    *,
+    limit: int | None = None,
+    event_type: str | None = None,
+    source: str | None = None,
+    db_path: str | None = None,
+) -> list[TelemetryEvent]:
+    """Retorna eventos com filtros opcionais."""
+
+    database_path = _resolve_db_path(db_path)
+    query = [
+        "SELECT source, event_type, payload, COALESCE(created_at, '')",
+        "FROM telemetry_events",
+    ]
+    clauses: list[str] = []
+    params: list[Any] = []
+    if event_type:
+        clauses.append("event_type = ?")
+        params.append(event_type)
+    if source:
+        clauses.append("source = ?")
+        params.append(source)
+    if clauses:
+        query.append("WHERE " + " AND ".join(clauses))
+    query.append("ORDER BY id DESC")
+    if limit:
+        query.append("LIMIT ?")
+        params.append(limit)
+
+    sql = " ".join(query)
+    async with aiosqlite.connect(database_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+
+    events: list[TelemetryEvent] = []
+    for row in rows:
+        events.append(
+            TelemetryEvent(
+                source=row["source"],
+                event_type=row["event_type"],
+                payload=json.loads(row["payload"]),
+                created_at=row["created_at"],
+            )
+        )
+    return events
+
+
+async def stream_events_as_csv(
+    *, db_path: str | None = None, fieldnames: Sequence[str] | None = None
+) -> AsyncIterator[str]:
+    """Gera o conteúdo CSV em streaming."""
+
+    database_path = _resolve_db_path(db_path)
+    header = list(fieldnames or ("id", "source", "event_type", "payload", "created_at"))
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+
+    writer.writerow(header)
+    yield buffer.getvalue()
+    buffer.seek(0)
+    buffer.truncate(0)
+
+    async with aiosqlite.connect(database_path) as conn:
+        async with conn.execute(
+            "SELECT id, source, event_type, payload, COALESCE(created_at, '') FROM telemetry_events ORDER BY id DESC"
+        ) as cursor:
+            async for row in cursor:
+                payload = row[3]
+                try:
+                    payload_obj = json.loads(payload)
+                    payload = json.dumps(payload_obj, ensure_ascii=False)
+                except json.JSONDecodeError:
+                    payload = str(payload)
+                writer.writerow([row[0], row[1], row[2], payload, row[4]])
+                yield buffer.getvalue()
+                buffer.seek(0)
+                buffer.truncate(0)
+
+
+async def export_events(
+    *, db_path: str | None = None, fieldnames: Sequence[str] | None = None
+) -> str:
+    """Exporta todos os eventos em uma única string CSV (útil para testes)."""
+
+    chunks: list[str] = []
+    async for chunk in stream_events_as_csv(db_path=db_path, fieldnames=fieldnames):
+        chunks.append(chunk)
+    return "".join(chunks)

--- a/kitsu-telemetry/tests/test_api.py
+++ b/kitsu-telemetry/tests/test_api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import uvicorn
+from httpx import AsyncClient
+
+# Garante que o pacote "api" possa ser importado via caminho relativo.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from api import main, storage  # noqa: E402
+
+
+@pytest.fixture()
+def telemetry_db(tmp_path, monkeypatch):
+    db_path = tmp_path / 'telemetry.db'
+    monkeypatch.setenv('TELEMETRY_DB_PATH', str(db_path))
+    return db_path
+
+
+@pytest.fixture()
+async def client(telemetry_db):
+    async with AsyncClient(app=main.app, base_url='http://testserver') as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(client):
+    response = await client.get('/health')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}
+
+
+@pytest.mark.asyncio
+async def test_event_flow_and_export(client, telemetry_db):
+    payload = {
+        'source': 'ui',
+        'event_type': 'emotion',
+        'payload': {'mood': 'happy', 'intensity': 0.8}
+    }
+
+    response = await client.post('/events', json=payload)
+    assert response.status_code == 200
+    event_id = response.json()['id']
+    assert event_id > 0
+
+    events_response = await client.get('/events', params={'limit': 5})
+    assert events_response.status_code == 200
+    items = events_response.json()
+    assert any(item['payload']['mood'] == 'happy' for item in items)
+
+    export_response = await client.get('/events/export')
+    assert export_response.status_code == 200
+    content = await export_response.aread()
+    text = content.decode('utf-8')
+    assert 'event_type' in text
+    assert 'emotion' in text
+
+
+def test_uvicorn_import(telemetry_db, monkeypatch):
+    monkeypatch.setenv('TELEMETRY_DB_PATH', str(telemetry_db))
+    config = uvicorn.Config('api.main:app', port=0, loop='asyncio')
+    app = config.load()
+    assert callable(app)
+
+
+@pytest.mark.asyncio
+async def test_storage_export_helper(telemetry_db):
+    await storage.init_db(db_path=str(telemetry_db))
+    await storage.insert_event(
+        storage.TelemetryEvent(source='bot', event_type='ping', payload={'ok': True}),
+        db_path=str(telemetry_db)
+    )
+    csv_content = await storage.export_events(db_path=str(telemetry_db))
+    assert 'source' in csv_content
+    assert 'bot' in csv_content

--- a/kitsu-telemetry/ui/package.json
+++ b/kitsu-telemetry/ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "kitsu-telemetry-ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^3.2.0",
+    "@sveltejs/kit": "^2.5.0",
+    "@tailwindcss/forms": "^0.5.7",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.38",
+    "svelte": "^4.2.12",
+    "svelte-check": "^3.6.8",
+    "tailwindcss": "^3.4.3",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.8"
+  },
+  "dependencies": {}
+}

--- a/kitsu-telemetry/ui/postcss.config.cjs
+++ b/kitsu-telemetry/ui/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/kitsu-telemetry/ui/src/app.d.ts
+++ b/kitsu-telemetry/ui/src/app.d.ts
@@ -1,0 +1,12 @@
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+declare global {
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface Platform {}
+  }
+}
+
+export {};

--- a/kitsu-telemetry/ui/src/lib/api.ts
+++ b/kitsu-telemetry/ui/src/lib/api.ts
@@ -1,0 +1,39 @@
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8001';
+
+type EventFilters = {
+  limit?: number;
+  event_type?: string;
+  source?: string;
+};
+
+export async function fetchRecentEvents(filters: EventFilters = {}) {
+  const params = new URLSearchParams();
+  if (filters.limit) params.set('limit', String(filters.limit));
+  if (filters.event_type) params.set('event_type', filters.event_type);
+  if (filters.source) params.set('source', filters.source);
+  const response = await fetch(`${API_BASE}/events?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error('Não foi possível obter eventos.');
+  }
+  return response.json();
+}
+
+export async function sendTelemetry(payload: Record<string, unknown>) {
+  const response = await fetch(`${API_BASE}/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    throw new Error('Falha ao enviar evento.');
+  }
+  return response.json();
+}
+
+export async function downloadTelemetryCsv(): Promise<string> {
+  const response = await fetch(`${API_BASE}/events/export`);
+  if (!response.ok) {
+    throw new Error('Falha ao exportar CSV.');
+  }
+  return response.text();
+}

--- a/kitsu-telemetry/ui/src/lib/ws.ts
+++ b/kitsu-telemetry/ui/src/lib/ws.ts
@@ -1,0 +1,101 @@
+import { readable, type Readable } from 'svelte/store';
+
+type MetricPayload = {
+  fps: number;
+  cpu: number;
+  gpu: number;
+  viewers: number;
+  vu: number[];
+};
+
+type ConsolePayload = {
+  level: 'info' | 'warning' | 'error';
+  message: string;
+};
+
+export type TelemetryMessage =
+  | { type: 'metrics'; data: MetricPayload }
+  | { type: 'console'; data: ConsolePayload }
+  | { type: 'expression'; data: { expression: string } };
+
+const LEVELS = ['info', 'warning', 'error'] as const;
+const EXPRESSIONS = ['Happy', 'Surprised', 'Cool', 'Thinking'];
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export class MockTelemetrySocket {
+  private readonly listeners = new Set<(message: TelemetryMessage) => void>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly interval = 1200) {}
+
+  connect(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      const metricPayload: MetricPayload = {
+        fps: randomInt(50, 120),
+        cpu: randomInt(20, 90),
+        gpu: randomInt(10, 95),
+        viewers: randomInt(5, 1500),
+        vu: Array.from({ length: 12 }, () => Math.random())
+      };
+      this.emit({ type: 'metrics', data: metricPayload });
+
+      if (Math.random() > 0.6) {
+        const message: ConsolePayload = {
+          level: LEVELS[randomInt(0, LEVELS.length - 1)],
+          message: `Mock log ${new Date().toLocaleTimeString()} - ${Math.random()
+            .toString(16)
+            .slice(2, 7)}`
+        };
+        this.emit({ type: 'console', data: message });
+      }
+
+      if (Math.random() > 0.75) {
+        this.emit({
+          type: 'expression',
+          data: { expression: EXPRESSIONS[randomInt(0, EXPRESSIONS.length - 1)] }
+        });
+      }
+    }, this.interval);
+  }
+
+  disconnect(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  onMessage(callback: (message: TelemetryMessage) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  private emit(message: TelemetryMessage): void {
+    for (const listener of this.listeners) {
+      listener(message);
+    }
+  }
+}
+
+export interface TelemetryStream {
+  socket: MockTelemetrySocket;
+  subscribe: Readable<TelemetryMessage | null>['subscribe'];
+}
+
+export function createTelemetryStream(interval = 1200): TelemetryStream {
+  const socket = new MockTelemetrySocket(interval);
+  const store = readable<TelemetryMessage | null>(null, (set) => {
+    socket.connect();
+    const unsubscribe = socket.onMessage((message) => set(message));
+    return () => {
+      unsubscribe();
+      socket.disconnect();
+    };
+  });
+
+  return { socket, subscribe: store.subscribe };
+}

--- a/kitsu-telemetry/ui/src/routes/+page.svelte
+++ b/kitsu-telemetry/ui/src/routes/+page.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { createTelemetryStream, type TelemetryMessage } from '$lib/ws';
+  import { downloadTelemetryCsv, fetchRecentEvents } from '$lib/api';
+
+  const telemetry = createTelemetryStream();
+
+  type MetricState = {
+    fps: number;
+    cpu: number;
+    gpu: number;
+    viewers: number;
+    vu: number[];
+  };
+
+  let metrics: MetricState = {
+    fps: 0,
+    cpu: 0,
+    gpu: 0,
+    viewers: 0,
+    vu: Array.from({ length: 12 }, () => 0)
+  };
+
+  let consoleLines: { level: string; message: string }[] = [];
+  let activeExpression = 'Happy';
+  let energy = 60;
+  let micGain = 40;
+  let csvStatus = '';
+  let recentEvents: Array<Record<string, unknown>> = [];
+
+  const expressions = ['Happy', 'Surprised', 'Cool', 'Thinking', 'Sleepy'];
+
+  function handleTelemetry(message: TelemetryMessage | null) {
+    if (!message) return;
+    if (message.type === 'metrics') {
+      metrics = message.data;
+    }
+    if (message.type === 'console') {
+      consoleLines = [{ level: message.data.level, message: message.data.message }, ...consoleLines].slice(0, 20);
+    }
+    if (message.type === 'expression') {
+      activeExpression = message.data.expression;
+    }
+  }
+
+  async function hydrateRecentEvents() {
+    try {
+      recentEvents = await fetchRecentEvents({ limit: 5 });
+    } catch (error) {
+      consoleLines = [{ level: 'warning', message: 'Não foi possível buscar eventos recentes.' }, ...consoleLines];
+    }
+  }
+
+  async function handleExport() {
+    csvStatus = 'Gerando CSV...';
+    try {
+      const csvContent = await downloadTelemetryCsv();
+      const file = new Blob([csvContent], { type: 'text/csv' });
+      const url = URL.createObjectURL(file);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `telemetria-${new Date().toISOString()}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+      csvStatus = 'Exportação concluída!';
+    } catch (error) {
+      csvStatus = 'Falha ao exportar CSV.';
+    }
+  }
+
+  onMount(() => {
+    const unsubscribe = telemetry.subscribe(handleTelemetry);
+    hydrateRecentEvents();
+    return () => unsubscribe();
+  });
+</script>
+
+<svelte:head>
+  <title>Dashboard de Telemetria</title>
+</svelte:head>
+
+<div class="min-h-screen bg-slate-950 text-slate-50">
+  <div class="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10">
+    <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <h1 class="text-3xl font-semibold tracking-tight">Kitsu Telemetry</h1>
+      <div class="flex items-center gap-3">
+        <button
+          class="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 shadow transition hover:bg-emerald-400"
+          on:click={handleExport}
+          aria-label="Exportar eventos em CSV"
+        >
+          Exportar CSV
+        </button>
+        <span class="text-sm text-slate-300" aria-live="polite">{csvStatus}</span>
+      </div>
+    </header>
+
+    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4" aria-label="Métricas principais">
+      <div class="rounded-xl border border-white/10 bg-slate-900/60 p-4 shadow">
+        <h2 class="text-sm uppercase text-slate-400">FPS</h2>
+        <p class="text-3xl font-semibold">{metrics.fps}</p>
+      </div>
+      <div class="rounded-xl border border-white/10 bg-slate-900/60 p-4 shadow">
+        <h2 class="text-sm uppercase text-slate-400">CPU</h2>
+        <p class="text-3xl font-semibold">{metrics.cpu}%</p>
+      </div>
+      <div class="rounded-xl border border-white/10 bg-slate-900/60 p-4 shadow">
+        <h2 class="text-sm uppercase text-slate-400">GPU</h2>
+        <p class="text-3xl font-semibold">{metrics.gpu}%</p>
+      </div>
+      <div class="rounded-xl border border-white/10 bg-slate-900/60 p-4 shadow">
+        <h2 class="text-sm uppercase text-slate-400">Viewers</h2>
+        <p class="text-3xl font-semibold">{metrics.viewers}</p>
+      </div>
+    </section>
+
+    <section class="grid gap-6 lg:grid-cols-[2fr,1fr]" aria-label="Detalhes e controles">
+      <div class="flex flex-col gap-6">
+        <article class="rounded-xl border border-white/10 bg-slate-900/70 p-4 shadow">
+          <header class="mb-3 flex items-center justify-between">
+            <h2 class="text-lg font-medium">Console</h2>
+            <span class="text-xs text-slate-400">Últimos {consoleLines.length} eventos</span>
+          </header>
+          <div class="h-48 overflow-auto rounded-md border border-white/5 bg-black/40 p-3 font-mono text-xs">
+            {#if consoleLines.length === 0}
+              <p class="text-slate-400">Aguardando eventos...</p>
+            {:else}
+              {#each consoleLines as line, index (line.level + '-' + index + '-' + line.message)}
+                <div class={`mb-1 rounded px-2 py-1 ${line.level === 'error'
+                  ? 'bg-red-500/20 text-red-300'
+                  : line.level === 'warning'
+                  ? 'bg-amber-500/20 text-amber-200'
+                  : 'bg-emerald-500/20 text-emerald-200'}`}>
+                  [{line.level.toUpperCase()}] {line.message}
+                </div>
+              {/each}
+            {/if}
+          </div>
+        </article>
+
+        <article class="rounded-xl border border-white/10 bg-slate-900/70 p-4 shadow" aria-label="VU Meter">
+          <header class="mb-4 flex items-center justify-between">
+            <h2 class="text-lg font-medium">Níveis de Áudio</h2>
+            <span class="text-xs text-slate-400">Mock WebSocket</span>
+          </header>
+          <div class="flex h-40 items-end gap-2">
+            {#each metrics.vu as level, index}
+              <div
+                class="flex-1 rounded-t bg-gradient-to-t from-emerald-500/50 to-emerald-300"
+                style={`height: ${Math.max(level * 100, 5)}%`}
+                aria-label={`Canal ${index + 1} com nível ${(level * 100).toFixed(0)}%`}
+              ></div>
+            {/each}
+          </div>
+        </article>
+      </div>
+
+      <aside class="flex flex-col gap-6">
+        <article class="rounded-xl border border-white/10 bg-slate-900/70 p-4 shadow" aria-label="Controles de expressão">
+          <h2 class="text-lg font-medium">Expressões</h2>
+          <div class="mt-3 grid grid-cols-2 gap-2">
+            {#each expressions as expression}
+              <button
+                class={`rounded-lg px-3 py-2 text-sm font-semibold transition ${
+                  expression === activeExpression
+                    ? 'bg-emerald-400 text-emerald-950'
+                    : 'bg-slate-800 hover:bg-slate-700'
+                }`}
+                type="button"
+                aria-pressed={expression === activeExpression}
+                on:click={() => (activeExpression = expression)}
+              >
+                {expression}
+              </button>
+            {/each}
+          </div>
+          <p class="mt-4 text-sm text-slate-300">Atual: <span class="font-semibold">{activeExpression}</span></p>
+        </article>
+
+        <article class="rounded-xl border border-white/10 bg-slate-900/70 p-4 shadow" aria-label="Ajustes do avatar">
+          <h2 class="text-lg font-medium">Ajustes</h2>
+          <div class="mt-4 space-y-4">
+            <label class="flex flex-col gap-2 text-sm font-medium">
+              Energia ({energy}%)
+              <input
+                type="range"
+                min="0"
+                max="100"
+                bind:value={energy}
+                class="range"
+                aria-valuenow={energy}
+                aria-label="Energia do avatar"
+              />
+            </label>
+            <label class="flex flex-col gap-2 text-sm font-medium">
+              Ganho do microfone ({micGain}%)
+              <input
+                type="range"
+                min="0"
+                max="100"
+                bind:value={micGain}
+                class="range"
+                aria-valuenow={micGain}
+                aria-label="Ganho do microfone"
+              />
+            </label>
+          </div>
+        </article>
+
+        <article class="rounded-xl border border-white/10 bg-slate-900/70 p-4 shadow" aria-label="Eventos recentes">
+          <h2 class="text-lg font-medium">Eventos recentes</h2>
+          <ul class="mt-3 space-y-2 text-xs">
+            {#if recentEvents.length === 0}
+              <li class="text-slate-400">Nenhum evento disponível.</li>
+            {:else}
+              {#each recentEvents as event, index}
+                <li class="rounded bg-slate-800/70 p-2">
+                  <p class="font-semibold">{event.event_type ?? 'evento'}</p>
+                  <p class="text-slate-300">Origem: {event.source ?? 'desconhecida'}</p>
+                  <p class="text-slate-400">Payload: {JSON.stringify(event.payload)}</p>
+                  <p class="text-slate-500">#{index + 1}</p>
+                </li>
+              {/each}
+            {/if}
+          </ul>
+        </article>
+      </aside>
+    </section>
+  </div>
+</div>
+
+<style lang="postcss">
+  .range {
+    @apply h-2 w-full appearance-none rounded-full bg-slate-800;
+  }
+  .range::-webkit-slider-thumb {
+    @apply h-4 w-4 cursor-pointer appearance-none rounded-full bg-emerald-400 shadow;
+  }
+  .range::-moz-range-thumb {
+    @apply h-4 w-4 cursor-pointer rounded-full bg-emerald-400 shadow;
+  }
+</style>

--- a/kitsu-telemetry/ui/svelte.config.js
+++ b/kitsu-telemetry/ui/svelte.config.js
@@ -1,0 +1,12 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import adapter from '@sveltejs/adapter-auto';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  kit: {
+    adapter: adapter()
+  },
+  preprocess: vitePreprocess()
+};
+
+export default config;

--- a/kitsu-telemetry/ui/tailwind.config.cjs
+++ b/kitsu-telemetry/ui/tailwind.config.cjs
@@ -1,0 +1,9 @@
+const config = {
+  content: ['./src/**/*.{html,js,svelte,ts}'],
+  theme: {
+    extend: {}
+  },
+  plugins: [require('@tailwindcss/forms')]
+};
+
+module.exports = config;

--- a/kitsu-telemetry/ui/tsconfig.json
+++ b/kitsu-telemetry/ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "$lib/*": ["src/lib/*"]
+    }
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules/*"]
+}

--- a/kitsu-telemetry/ui/vite.config.ts
+++ b/kitsu-telemetry/ui/vite.config.ts
@@ -1,0 +1,11 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import type { UserConfig } from 'vite';
+
+const config: UserConfig = {
+  plugins: [sveltekit()],
+  server: {
+    host: '0.0.0.0'
+  }
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add telemetry FastAPI app with ingestion, querying, and CSV export backed by SQLite storage
- scaffold SvelteKit + Tailwind UI with mocked telemetry stream, controls, and CSV export trigger
- document environment setup and provide smoke tests for health, export, and uvicorn import

## Testing
- pytest -q *(fails: missing FastAPI/uvicorn dependencies in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57bd72bbc832c9d28ab75f5bbe71b