### PR TITLE
chore: improve windows dx baseline

### DIFF
--- a/kitsu-vtuber-ai/.env.example
+++ b/kitsu-vtuber-ai/.env.example
@@ -1,16 +1,46 @@
+# Core runtime --------------------------------------------------------------
+PYTHONUTF8=1
+LOG_LEVEL=INFO
+
+# Orchestrator --------------------------------------------------------------
 ORCH_HOST=127.0.0.1
 ORCH_PORT=8000
 ORCH_CORS_ALLOW_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 TELEMETRY_API_URL=http://localhost:8001/api
-TWITCH_TOKEN=
-OBS_HOST=localhost
-OBS_PORT=4455
-OBS_PASSWORD=
-VTS_PORT=8001
-OLLAMA_URL=http://localhost:11434
-POLICY_FORCE_MOCK=0
-TTS_MODEL_NAME=coqui-tts-model
-TTS_BACKUP=Piper
-ASR_MODEL=medium.en
 SAFETY_MODE=family
 RESTORE_CONTEXT=false
+
+# Automatic Speech Recognition (ASR) ---------------------------------------
+ASR_MODEL=small.en
+ASR_VAD=webrtc
+ASR_PARTIAL_INTERVAL_MS=200
+
+# Policy / LLM --------------------------------------------------------------
+OLLAMA_URL=http://localhost:11434
+LLM_MODEL_NAME=mixtral
+POLICY_FORCE_MOCK=0
+POLICY_FAMILY_FRIENDLY=1
+
+# Text-to-Speech ------------------------------------------------------------
+TTS_ENGINE=piper
+TTS_MODEL_NAME=coqui-tts-model
+TTS_BACKUP=Piper
+PIPER_VOICE_DIR=./models/piper/voices
+PIPER_VOICE=en_US-amy-low.onnx
+TTS_OUTPUT_DIR=artifacts/tts
+
+# Twitch integration --------------------------------------------------------
+TWITCH_CHANNEL=
+TWITCH_OAUTH_TOKEN=
+
+# OBS controller ------------------------------------------------------------
+OBS_WS_URL=ws://127.0.0.1:4455
+OBS_WS_PASSWORD=
+
+# VTube Studio --------------------------------------------------------------
+VTS_WS_URL=ws://127.0.0.1:8001
+VTS_TOKEN=
+
+# Memory / moderation -------------------------------------------------------
+MEMORY_DB_PATH=./memory.sqlite3
+MODERATION_STRICT=0

--- a/kitsu-vtuber-ai/.gitignore
+++ b/kitsu-vtuber-ai/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .DS_Store
 .idea/
 .vscode/
+scripts/.service-state/

--- a/kitsu-vtuber-ai/.pre-commit-config.yaml
+++ b/kitsu-vtuber-ai/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     hooks:
       - id: black
         files: ^(apps|libs|tests)/
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        files: ^(apps|libs|tests)/
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:

--- a/kitsu-vtuber-ai/README.md
+++ b/kitsu-vtuber-ai/README.md
@@ -36,18 +36,35 @@ Kitsu.exe é a espinha dorsal da VTuber IA "Kitsu" – uma raposa kawaii e caót
    ```bash
    poetry run uvicorn apps.control_panel_backend.main:app --reload
    ```
-5. (Opcional) Suba todos os workers (incluindo o novo orquestrador e os stubs) em paralelo via PowerShell:
-   ```powershell
-   scripts/run_all.ps1
-   ```
-
-6. Para inspecionar o orquestrador (FastAPI + WebSocket):
+5. Para inspecionar o orquestrador (FastAPI + WebSocket):
    ```bash
    poetry run uvicorn apps.orchestrator.main:app --reload --host ${ORCH_HOST:-127.0.0.1} --port ${ORCH_PORT:-8000}
    curl http://${ORCH_HOST:-127.0.0.1}:${ORCH_PORT:-8000}/status
    ```
 
 > **Atribuição**: O modelo LLM padrão é **Llama 3 8B Instruct** servido pelo Ollama.
+
+### Como rodar sem Docker (Windows)
+
+1. Instale o [Python 3.11](https://www.python.org/downloads/windows/) (habilite "Add python.exe to PATH") e o [Poetry](https://python-poetry.org/docs/).
+2. Clone o repositório, abra **PowerShell 7+ (pwsh)** e configure o ambiente virtual:
+   ```powershell
+   poetry env use 3.11
+   poetry install
+   ```
+3. Copie o arquivo de variáveis: `Copy-Item .env.example .env` e edite as credenciais (Twitch OAuth, OBS, VTS etc.).
+4. Opcional porém recomendado: instale os hooks locais com `poetry run pre-commit install` para ativar `ruff`, `black`, `isort` e `mypy` antes dos commits.
+5. Use os scripts de automação em `scripts/` para iniciar ou encerrar cada serviço individualmente:
+   ```powershell
+   pwsh scripts/run_orchestrator.ps1 -Action start   # inicia o orquestrador (FastAPI)
+   pwsh scripts/run_asr.ps1 -Action status           # verifica o worker de ASR
+   pwsh scripts/run_tts.ps1 -Action stop             # encerra o worker de TTS
+   ```
+6. Para subir tudo de uma vez (sem Docker), execute:
+   ```powershell
+   pwsh scripts/run_all_no_docker.ps1 -Action start
+   ```
+   Utilize `-Action stop` para derrubar todos os serviços ou `-Action status` para conferir os PIDs ativos.
 
 ## Variáveis de ambiente essenciais
 As variáveis abaixo controlam como o orquestrador expõe seus endpoints HTTP/WebSocket e como os eventos são encaminhados para o módulo de telemetria:

--- a/kitsu-vtuber-ai/pyproject.toml
+++ b/kitsu-vtuber-ai/pyproject.toml
@@ -29,9 +29,13 @@ ruff = "^0.4.7"
 black = "^24.4.2"
 mypy = "^1.10.0"
 pre-commit = "^3.7.0"
+isort = "^5.13.2"
 
 [tool.mypy]
 ignore_missing_imports = true
+
+[tool.isort]
+profile = "black"
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]

--- a/kitsu-vtuber-ai/scripts/run_all_no_docker.ps1
+++ b/kitsu-vtuber-ai/scripts/run_all_no_docker.ps1
@@ -1,0 +1,28 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$services = @(
+    'run_orchestrator.ps1',
+    'run_asr.ps1',
+    'run_policy.ps1',
+    'run_tts.ps1',
+    'run_twitch.ps1',
+    'run_obs.ps1',
+    'run_vts.ps1'
+)
+
+foreach ($script in $services) {
+    $path = Join-Path $PSScriptRoot $script
+    if (-not (Test-Path $path)) {
+        Write-Warning "Script $script not found."
+        continue
+    }
+
+    Write-Host "[kitsu] Executing $script ($Action)..." -ForegroundColor Magenta
+    & $path -Action $Action
+}
+
+if ($Action -eq 'start') {
+    Write-Host "[kitsu] All services requested. Use '-Action status' to inspect running processes." -ForegroundColor Green
+}

--- a/kitsu-vtuber-ai/scripts/run_asr.ps1
+++ b/kitsu-vtuber-ai/scripts/run_asr.ps1
@@ -1,0 +1,12 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$arguments = @('run', 'python', '-m', 'apps.asr_worker.main')
+
+& $serviceManager `
+    -ServiceName 'asr_worker' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "Streaming ASR worker (faster-whisper stub)"

--- a/kitsu-vtuber-ai/scripts/run_obs.ps1
+++ b/kitsu-vtuber-ai/scripts/run_obs.ps1
@@ -1,0 +1,12 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$arguments = @('run', 'python', '-m', 'apps.obs_controller.main')
+
+& $serviceManager `
+    -ServiceName 'obs_controller' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "OBS WebSocket controller"

--- a/kitsu-vtuber-ai/scripts/run_orchestrator.ps1
+++ b/kitsu-vtuber-ai/scripts/run_orchestrator.ps1
@@ -1,0 +1,18 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$host = if ($env:ORCH_HOST) { $env:ORCH_HOST } else { '127.0.0.1' }
+$port = if ($env:ORCH_PORT) { $env:ORCH_PORT } else { '8000' }
+
+$arguments = @('run', 'uvicorn', 'apps.orchestrator.main:app', '--host', $host, '--port', $port)
+if ($env:UVICORN_RELOAD -eq '1') {
+    $arguments += '--reload'
+}
+
+& $serviceManager `
+    -ServiceName 'orchestrator' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "FastAPI orchestrator (serves /status and /stream)"

--- a/kitsu-vtuber-ai/scripts/run_policy.ps1
+++ b/kitsu-vtuber-ai/scripts/run_policy.ps1
@@ -1,0 +1,18 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$host = if ($env:POLICY_HOST) { $env:POLICY_HOST } else { '0.0.0.0' }
+$port = if ($env:POLICY_PORT) { $env:POLICY_PORT } else { '8081' }
+
+$arguments = @('run', 'uvicorn', 'apps.policy_worker.main:app', '--host', $host, '--port', $port)
+if ($env:UVICORN_RELOAD -eq '1') {
+    $arguments += '--reload'
+}
+
+& $serviceManager `
+    -ServiceName 'policy_worker' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "Policy worker (Ollama Mixtral streaming API)"

--- a/kitsu-vtuber-ai/scripts/run_tts.ps1
+++ b/kitsu-vtuber-ai/scripts/run_tts.ps1
@@ -1,0 +1,12 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$arguments = @('run', 'python', '-m', 'apps.tts_worker.main')
+
+& $serviceManager `
+    -ServiceName 'tts_worker' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "Text-to-speech worker (Piper / Coqui pipeline)"

--- a/kitsu-vtuber-ai/scripts/run_twitch.ps1
+++ b/kitsu-vtuber-ai/scripts/run_twitch.ps1
@@ -1,0 +1,12 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$arguments = @('run', 'python', '-m', 'apps.twitch_ingest.main')
+
+& $serviceManager `
+    -ServiceName 'twitch_ingest' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "Twitch chat ingest (OAuth + commands)"

--- a/kitsu-vtuber-ai/scripts/run_vts.ps1
+++ b/kitsu-vtuber-ai/scripts/run_vts.ps1
@@ -1,0 +1,12 @@
+param(
+    [ValidateSet("start", "stop", "status")][string]$Action = "start"
+)
+
+$serviceManager = Join-Path $PSScriptRoot 'service_manager.ps1'
+$arguments = @('run', 'python', '-m', 'apps.avatar_controller.main')
+
+& $serviceManager `
+    -ServiceName 'avatar_controller' `
+    -Command $arguments `
+    -Action $Action `
+    -Description "VTube Studio controller"

--- a/kitsu-vtuber-ai/scripts/service_manager.ps1
+++ b/kitsu-vtuber-ai/scripts/service_manager.ps1
@@ -1,0 +1,92 @@
+param(
+    [Parameter(Mandatory = $true)][string]$ServiceName,
+    [Parameter(Mandatory = $true)][string[]]$Command,
+    [ValidateSet("start", "stop", "status")][string]$Action = "start",
+    [string]$Description = "",
+    [string]$Executable = "poetry"
+)
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$stateDir = Join-Path $repoRoot 'scripts/.service-state'
+if (-not (Test-Path $stateDir)) {
+    New-Item -Path $stateDir -ItemType Directory | Out-Null
+}
+$pidFile = Join-Path $stateDir ("{0}.pid" -f $ServiceName)
+
+function Get-ServiceProcess {
+    param([int]$Pid)
+
+    try {
+        return Get-Process -Id $Pid -ErrorAction Stop
+    } catch {
+        return $null
+    }
+}
+
+switch ($Action) {
+    'start' {
+        if (Test-Path $pidFile) {
+            $existingPid = [int](Get-Content $pidFile)
+            $proc = Get-ServiceProcess -Pid $existingPid
+            if ($proc) {
+                Write-Warning "Service '$ServiceName' is already running (PID $existingPid)."
+                return
+            }
+        }
+
+        Write-Host "[kitsu] Starting $ServiceName..." -ForegroundColor Cyan
+        try {
+            $process = Start-Process -FilePath $Executable -ArgumentList $Command -PassThru -WorkingDirectory $repoRoot -WindowStyle Normal
+            Set-Content -Path $pidFile -Value $process.Id
+            Write-Host "[kitsu] $ServiceName started with PID $($process.Id)."
+        } catch {
+            Write-Error "Failed to start $ServiceName: $($_.Exception.Message)"
+        }
+    }
+    'stop' {
+        if (-not (Test-Path $pidFile)) {
+            Write-Warning "No PID file found for '$ServiceName'. Nothing to stop."
+            return
+        }
+
+        $pid = [int](Get-Content $pidFile)
+        $process = Get-ServiceProcess -Pid $pid
+        if (-not $process) {
+            Write-Warning "Process $pid for '$ServiceName' is no longer running. Cleaning up PID file."
+            Remove-Item $pidFile -ErrorAction SilentlyContinue
+            return
+        }
+
+        Write-Host "[kitsu] Stopping $ServiceName (PID $pid)..." -ForegroundColor Yellow
+        try {
+            Stop-Process -Id $pid -ErrorAction Stop
+            Write-Host "[kitsu] $ServiceName stopped."
+        } catch {
+            Write-Error "Failed to stop $ServiceName: $($_.Exception.Message)"
+        }
+
+        Remove-Item $pidFile -ErrorAction SilentlyContinue
+    }
+    'status' {
+        if (-not (Test-Path $pidFile)) {
+            Write-Host "[kitsu] $ServiceName is stopped." -ForegroundColor DarkGray
+            if ($Description) {
+                Write-Host "        $Description"
+            }
+            return
+        }
+
+        $pid = [int](Get-Content $pidFile)
+        $process = Get-ServiceProcess -Pid $pid
+        if ($process) {
+            Write-Host "[kitsu] $ServiceName running (PID $pid)." -ForegroundColor Green
+        } else {
+            Write-Host "[kitsu] $ServiceName has a stale PID file (PID $pid)." -ForegroundColor DarkYellow
+            Remove-Item $pidFile -ErrorAction SilentlyContinue
+        }
+
+        if ($Description) {
+            Write-Host "        $Description"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand the Windows-friendly `.env.example` with per-service defaults for orchestrator, ASR, policy, TTS, Twitch, OBS, and VTS
- add isort to the Poetry dev group and pre-commit stack while documenting the no-docker Windows workflow
- introduce reusable PowerShell launchers (individual + aggregate) with PID tracking for starting, stopping, and inspecting each worker

## Testing
- poetry run pytest -q *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_e_68ed02d8dc2c832c9c27ca1f8105c5a6