### PR TITLE
fix: resolve mypy regressions

### DIFF
--- a/kitsu-vtuber-ai/apps/avatar_controller/main.py
+++ b/kitsu-vtuber-ai/apps/avatar_controller/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 import secrets
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, Optional, Protocol
+from typing import Any, Awaitable, Callable, Dict, Optional, Protocol, cast
 
 from libs.common import configure_json_logging
 
@@ -51,7 +51,7 @@ class VTubeStudioClient:
         auth_token: Optional[str] = None,
         websocket_factory: Optional[WebSocketFactory] = None,
     ) -> None:
-        self._url = url or os.getenv("VTS_URL", "ws://127.0.0.1:8001")
+        self._url: str = url or os.getenv("VTS_URL", "ws://127.0.0.1:8001") or "ws://127.0.0.1:8001"
         self._auth_token = auth_token or os.getenv("VTS_AUTH_TOKEN")
         self._plugin_name = os.getenv("VTS_PLUGIN_NAME", "Kitsu.exe Controller")
         self._developer = os.getenv("VTS_DEVELOPER", "Kitsu.exe")
@@ -80,7 +80,8 @@ class VTubeStudioClient:
                 self._connected = True
                 return
             factory = self._factory or websockets.connect  # type: ignore[union-attr]
-            self._ws = await factory(self._url)
+            connection = await factory(self._url)
+            self._ws = cast(WebSocketLike, connection)
             await self._authenticate()
             self._connected = True
             logger.info("Connected to VTube Studio at %s", self._url)

--- a/kitsu-vtuber-ai/apps/control_panel_backend/main.py
+++ b/kitsu-vtuber-ai/apps/control_panel_backend/main.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Dict, Optional
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import status as http_status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -183,7 +184,7 @@ async def telemetry_export(
 @app.post(
     "/control/panic",
     response_model=Dict[str, Any],
-    status_code=status.HTTP_202_ACCEPTED,
+    status_code=http_status.HTTP_202_ACCEPTED,
 )
 async def control_panic(
     payload: PanicIn,

--- a/kitsu-vtuber-ai/apps/policy_worker/main.py
+++ b/kitsu-vtuber-ai/apps/policy_worker/main.py
@@ -325,7 +325,7 @@ async def _stream_ollama_response(
 
     latency_ms = (time.perf_counter() - start_time) * 1000
     stats = _extract_stats(final_metadata)
-    response = PolicyResponse(
+    policy_response = PolicyResponse(
         content=content,
         latency_ms=round(latency_ms, 2),
         source="ollama",
@@ -350,7 +350,7 @@ async def _stream_ollama_response(
             "stats": stats,
         },
     )
-    yield _format_sse("final", response.dict())
+    yield _format_sse("final", policy_response.dict())
 
 
 def build_mock_reply(payload: PolicyRequest) -> str:

--- a/kitsu-vtuber-ai/apps/soak_harness/main.py
+++ b/kitsu-vtuber-ai/apps/soak_harness/main.py
@@ -366,13 +366,15 @@ class SoakHarness:
         def _aggregate(values: Sequence[float]) -> Dict[str, Optional[float]]:
             if not values:
                 return {"avg": None, "p95": None, "max": None}
+            if len(values) > 1:
+                percentile = _percentile(values, 95.0)
+                assert percentile is not None
+                p95_value = round(percentile, 2)
+            else:
+                p95_value = round(values[0], 2)
             return {
                 "avg": round(statistics.fmean(values), 2),
-                "p95": (
-                    round(_percentile(values, 95.0), 2)
-                    if len(values) > 1
-                    else round(values[0], 2)
-                ),
+                "p95": p95_value,
                 "max": round(max(values), 2),
             }
 

--- a/kitsu-vtuber-ai/apps/tts_worker/service.py
+++ b/kitsu-vtuber-ai/apps/tts_worker/service.py
@@ -116,7 +116,7 @@ class CoquiSynthesizer:
         loop = asyncio.get_running_loop()
 
         def _run() -> None:
-            kwargs = {"file_path": destination}
+            kwargs: dict[str, object] = {"file_path": destination}
             if voice:
                 kwargs["speaker"] = voice
             self._tts.tts_to_file(text, **kwargs)

--- a/kitsu-vtuber-ai/apps/twitch_ingest/main.py
+++ b/kitsu-vtuber-ai/apps/twitch_ingest/main.py
@@ -8,7 +8,7 @@ import os
 import re
 import time
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Dict, Optional
+from typing import Awaitable, Callable, Dict, Optional, Protocol
 
 import httpx
 
@@ -31,6 +31,18 @@ CommandHandler = Callable[["ChatMessage"], Awaitable[None]]
 class ChatMessage:
     author: str
     content: str
+
+
+class TwitchBridge(Protocol):
+    async def toggle_tts(self, enabled: bool) -> None: ...
+
+    async def update_persona(
+        self, *, style: Optional[str], chaos: Optional[float], energy: Optional[float]
+    ) -> None: ...
+
+    async def set_scene(self, scene: str) -> None: ...
+
+    async def emit_chat(self, role: str, text: str) -> None: ...
 
 
 class RateLimiter:
@@ -97,9 +109,9 @@ class TwitchCommandRouter:
     )
 
     def __init__(
-        self, bridge: OrchestratorBridge, cooldown_seconds: float = 3.0
+        self, bridge: TwitchBridge, cooldown_seconds: float = 3.0
     ) -> None:
-        self._bridge = bridge
+        self._bridge: TwitchBridge = bridge
         self._handlers: Dict[str, CommandHandler] = {}
         self._rate_limiter = RateLimiter(cooldown_seconds)
         self._register_default_handlers()

--- a/kitsu-vtuber-ai/tests/test_asr_pipeline.py
+++ b/kitsu-vtuber-ai/tests/test_asr_pipeline.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import AsyncIterator, List, Tuple
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncIterator, List, Tuple, cast
 
 from apps.asr_worker.main import ASRConfig, SpeechPipeline, TranscriptionResult
 
@@ -33,9 +35,9 @@ class PatternVAD:
 
 @dataclass
 class Recorder:
-    events: List[Tuple[str, dict]]
+    events: List[Tuple[str, dict[str, object]]]
 
-    async def publish(self, event_type: str, payload: dict) -> None:
+    async def publish(self, event_type: str, payload: dict[str, object]) -> None:
         self.events.append((event_type, payload))
 
 
@@ -85,6 +87,7 @@ def test_pipeline_emits_partial_and_final_events() -> None:
         final_events = [payload for event, payload in recorded if event == "asr_final"]
         assert final_events, "Expected at least one final event"
         assert final_events[0]["text"] == "hello world"
-        assert final_events[0]["duration_ms"] > 0
+        duration = cast(float, final_events[0]["duration_ms"])
+        assert duration > 0
 
     asyncio.run(_scenario())

--- a/kitsu-vtuber-ai/tests/test_control_panel_backend.py
+++ b/kitsu-vtuber-ai/tests/test_control_panel_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, AsyncIterator, Dict, Generator, List
 
 import pytest
 
@@ -54,14 +54,14 @@ class StubGateway:
             }
         ]
 
-    async def telemetry_stream(self, path: str):
+    async def telemetry_stream(self, path: str) -> AsyncIterator[bytes]:
         self.telemetry_calls.append((path, {}))
         yield b"ts,type,json_payload\n"
         yield b'2025-10-10T10:00:00Z,control.mute,{"muted": true}\n'
 
 
 @pytest.fixture()
-def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
     gateway = StubGateway()
 
     async def _override_gateway() -> StubGateway:

--- a/kitsu-vtuber-ai/tests/test_twitch_ingest.py
+++ b/kitsu-vtuber-ai/tests/test_twitch_ingest.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import asyncio
 
@@ -17,7 +17,13 @@ class FakeBridge:
     async def set_scene(self, scene: str) -> None:
         self.calls.append(("set_scene", (scene,), {}))
 
-    async def update_persona(self, *, style, chaos, energy) -> None:
+    async def update_persona(
+        self,
+        *,
+        style: Optional[str],
+        chaos: Optional[float],
+        energy: Optional[float],
+    ) -> None:
         self.calls.append(
             ("update_persona", (), {"style": style, "chaos": chaos, "energy": energy})
         )


### PR DESCRIPTION
## Summary
- tighten optional dependency typing in the ASR worker so audio backends and orchestrator stubs satisfy the Protocol interfaces
- harden assorted services and tests (avatar controller, Twitch ingest, GPU telemetry, soak harness) to appease mypy by providing precise annotations and helper casts
- update policy/control panel tests and helpers to use typed fakes and generators for streaming responses

## Testing
- poetry run mypy .

------
https://chatgpt.com/codex/tasks/task_e_68ee3ce08308832c9b084e83301b4a46