### PR TITLE
fix: prevent PID variable collision in service manager

### DIFF
--- a/kitsu-vtuber-ai/scripts/service_manager.ps1
+++ b/kitsu-vtuber-ai/scripts/service_manager.ps1
@@ -35,10 +35,10 @@ function Resolve-LogDirectory {
 }
 
 function Get-ServiceProcess {
-    param([int]$Pid)
+    param([int]$ProcessId)
 
     try {
-        return Get-Process -Id $Pid -ErrorAction Stop
+        return Get-Process -Id $ProcessId -ErrorAction Stop
     } catch {
         return $null
     }
@@ -48,7 +48,7 @@ switch ($Action) {
     'start' {
         if (Test-Path $pidFile) {
             $existingPid = [int](Get-Content $pidFile)
-            $proc = Get-ServiceProcess -Pid $existingPid
+            $proc = Get-ServiceProcess -ProcessId $existingPid
             if ($proc) {
                 Write-Warning "Service '${ServiceName}' is already running (PID $existingPid)."
                 return
@@ -100,7 +100,7 @@ switch ($Action) {
         }
 
         $servicePid = [int](Get-Content $pidFile)
-        $process = Get-ServiceProcess -Pid $servicePid
+        $process = Get-ServiceProcess -ProcessId $servicePid
         if (-not $process) {
             Write-Warning "Process $servicePid for '${ServiceName}' is no longer running. Cleaning up PID file."
             Remove-Item $pidFile -ErrorAction SilentlyContinue
@@ -132,7 +132,7 @@ switch ($Action) {
         }
 
         $servicePid = [int](Get-Content $pidFile)
-        $process = Get-ServiceProcess -Pid $servicePid
+        $process = Get-ServiceProcess -ProcessId $servicePid
         if ($process) {
             Write-Host "[kitsu] ${ServiceName} running (PID $servicePid)." -ForegroundColor Green
             if (Test-Path $metaFile) {


### PR DESCRIPTION
## Summary
- rename the service manager's Get-ServiceProcess parameter to avoid conflicting with PowerShell's automatic `$PID`
- update all call sites to use the new parameter name

## Testing
- not run (pwsh not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ee566a9ae8832c956d5e99286e642c