### PR TITLE
Restore ASR VAD integration and runner loop

### DIFF
--- a/kitsu-vtuber-ai/apps/asr_worker/__init__.py
+++ b/kitsu-vtuber-ai/apps/asr_worker/__init__.py
@@ -1,6 +1,7 @@
 from .config import ASRConfig, load_config
 from .main import main, run_forever
 from .pipeline import SimpleASRPipeline
+from .vad import VoiceActivityDetector, build_vad
 
 SpeechPipeline = SimpleASRPipeline
 from .runner import run
@@ -12,7 +13,9 @@ __all__ = [
     "TranscriptionResult",
     "SimpleASRPipeline",
     "SpeechPipeline",
+    "VoiceActivityDetector",
     "build_transcriber",
+    "build_vad",
     "load_config",
     "main",
     "run",

--- a/kitsu-vtuber-ai/apps/asr_worker/pipeline.py
+++ b/kitsu-vtuber-ai/apps/asr_worker/pipeline.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from typing import Any, AsyncIterator, Dict, Optional
+from typing import AsyncIterator, Dict, Optional
 
 from .config import ASRConfig
 from .logger import logger
 from .metrics import ASRTelemetry
 from .orchestrator import OrchestratorPublisher
 from .transcription import Transcriber
+from .vad import VoiceActivityDetector
 
 DEFAULT_ENERGY_THRESHOLD = float(
     os.getenv("ASR_ENERGY_THRESHOLD", "300.0")
@@ -22,9 +23,9 @@ class SimpleASRPipeline:
         config: ASRConfig,
         transcriber: Transcriber,
         *,
-        vad: Any | None = None,
+        vad: VoiceActivityDetector | None = None,
         energy_threshold: float = DEFAULT_ENERGY_THRESHOLD,
-        min_duration_ms: int = 400,
+        min_duration_ms: int = 0,
         silence_duration_ms: Optional[int] = None,
         allow_non_english: bool | None = None,
         orchestrator: OrchestratorPublisher | None = None,
@@ -40,17 +41,20 @@ class SimpleASRPipeline:
         self._last_partial_at = 0.0
         self._last_partial_text = ""
         self._energy_threshold = energy_threshold
-        self._min_duration = max(min_duration_ms, config.frame_duration_ms)
-        self._silence_required = (
-            (silence_duration_ms or config.silence_duration_ms)
-            // config.frame_duration_ms
+        self._min_duration = max(0, min_duration_ms)
+        silence_ms = silence_duration_ms or config.silence_duration_ms
+        self._silence_required = max(
+            1,
+            int(
+                (silence_ms + config.frame_duration_ms - 1)
+                // config.frame_duration_ms
+            ),
         )
-        self._silence_required = max(1, self._silence_required)
-        env_flag = os.getenv("ASR_ALLOW_NON_ENGLISH")
+        env_flag = os.getenv("ASR_ALLOW_NON_ENGLISH", "0")
         self._allow_non_english = (
             allow_non_english
             if allow_non_english is not None
-            else (env_flag or "1").lower() in {"1", "true", "yes"}
+            else env_flag.lower() in {"1", "true", "yes"}
         )
         if self._allow_non_english:
             logger.debug("ASR pipeline allowing all languages for transcripts")
@@ -66,7 +70,14 @@ class SimpleASRPipeline:
                 await self._handle_frame(frame)
         except asyncio.CancelledError:
             raise
-        logger.warning("Audio frame stream finished; waiting for next capture cycle")
+        else:
+            await self._flush_active_segment()
+            logger.warning("Audio frame stream finished; waiting for next capture cycle")
+
+    async def process(self, frames: AsyncIterator[bytes]) -> None:
+        """Backward-compatible alias for legacy callers/tests."""
+
+        await self.run(frames)
 
     async def _handle_frame(self, frame: bytes) -> None:
         if len(frame) != self._config.frame_bytes:
@@ -106,11 +117,7 @@ class SimpleASRPipeline:
         if self._silence_frames < self._silence_required:
             return
         await self._emit_segment()
-        self._buffer.clear()
-        self._speech_active = False
-        self._silence_frames = 0
-        self._last_partial_text = ""
-        self._last_partial_at = 0.0
+        self._reset_segment_state()
 
     async def _emit_segment(self) -> None:
         if not self._buffer:
@@ -272,11 +279,30 @@ class SimpleASRPipeline:
             logger.debug("Telemetry segment_final failed", exc_info=True)
 
     def _is_silence(self, frame: bytes) -> bool:
+        if self._vad is not None:
+            try:
+                return not bool(self._vad.is_speech(frame))
+            except Exception:  # pragma: no cover - defensive guard
+                logger.debug("VAD check failed; falling back to energy threshold", exc_info=True)
         if not frame:
             return True
         mv = memoryview(frame).cast("h")
         energy = sum(sample * sample for sample in mv) / max(1, len(mv))
         return energy < self._energy_threshold
+
+    async def _flush_active_segment(self) -> None:
+        if not self._speech_active:
+            return
+        if self._buffer:
+            await self._emit_segment()
+        self._reset_segment_state()
+
+    def _reset_segment_state(self) -> None:
+        self._buffer.clear()
+        self._speech_active = False
+        self._silence_frames = 0
+        self._last_partial_text = ""
+        self._last_partial_at = 0.0
 
 
 __all__ = ["SimpleASRPipeline"]

--- a/kitsu-vtuber-ai/apps/asr_worker/pipeline.py
+++ b/kitsu-vtuber-ai/apps/asr_worker/pipeline.py
@@ -279,7 +279,9 @@ class SimpleASRPipeline:
             logger.debug("Telemetry segment_final failed", exc_info=True)
 
     def _is_silence(self, frame: bytes) -> bool:
-        if self._vad is not None:
+        if self._vad is not None and getattr(
+            self._vad, "supports_silence_detection", True
+        ):
             try:
                 return not bool(self._vad.is_speech(frame))
             except Exception:  # pragma: no cover - defensive guard

--- a/kitsu-vtuber-ai/apps/asr_worker/runner.py
+++ b/kitsu-vtuber-ai/apps/asr_worker/runner.py
@@ -2,56 +2,107 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 from .audio import MicrophoneStream
-from .config import load_config
+from .config import ASRConfig, load_config
 from .logger import logger
 from .metrics import create_telemetry
 from .orchestrator import OrchestratorClient
 from .pipeline import SimpleASRPipeline
 from .transcription import build_transcriber
+from .vad import PassthroughVAD, build_vad
 
 
-async def run() -> None:
-    config = load_config()
+SpeechPipeline = SimpleASRPipeline
+
+
+@asynccontextmanager
+async def acquire_audio_source(config: ASRConfig) -> AsyncIterator[MicrophoneStream]:
+    async with MicrophoneStream(config) as source:
+        yield source
+
+
+async def run(config: ASRConfig | None = None) -> None:
+    config = config or load_config()
     orchestrator = OrchestratorClient(config.orchestrator_url)
     telemetry = create_telemetry()
+    attempt = 0
+    backoff = 1.0
     try:
         transcriber = build_transcriber(config)
-        pipeline = SimpleASRPipeline(
-            config,
-            transcriber,
-            orchestrator=orchestrator,
-            telemetry=telemetry,
-        )
-        logger.info(
-            "ASR worker ready (model=%s, sample_rate=%sHz, frame_ms=%s, partial_interval_ms=%s)",
-            config.model_name,
-            config.sample_rate,
-            config.frame_duration_ms,
-            config.partial_interval_ms,
-        )
         while True:
+            attempt += 1
+            current_backoff = backoff
             try:
-                async with MicrophoneStream(config) as source:
-                    await pipeline.run(source.frames())
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.exception("ASR worker crashed")
-                await asyncio.sleep(1)
+                vad = build_vad(config)
+            except Exception as exc:
+                logger.exception("ASR worker failed to initialise VAD: %s", exc)
+                logger.warning(
+                    "Falling back to passthrough VAD. Set ASR_VAD=none to disable VAD explicitly."
+                )
+                vad = PassthroughVAD(config.frame_bytes)
+
+            pipeline = SpeechPipeline(
+                config=config,
+                transcriber=transcriber,
+                vad=vad,
+                orchestrator=orchestrator,
+                telemetry=telemetry,
+            )
+
+            if attempt == 1:
+                logger.info(
+                    (
+                        "Starting ASR worker with model=%s, sample_rate=%s Hz, frame_ms=%s, "
+                        "partial_interval_ms=%s, vad=%s"
+                    ),
+                    config.model_name,
+                    config.sample_rate,
+                    config.frame_duration_ms,
+                    config.partial_interval_ms,
+                    vad.__class__.__name__,
+                )
             else:
-                logger.warning("Audio stream finished; restarting after short delay")
-                await asyncio.sleep(0.5)
+                logger.warning(
+                    "ASR worker restarting audio capture (attempt %d, backoff %.1fs)",
+                    attempt,
+                    current_backoff,
+                )
+
+            await telemetry.cycle_started(attempt, current_backoff)
+
+            try:
+                async with acquire_audio_source(config) as source:
+                    await pipeline.process(source.frames())
+                logger.warning("Audio frame stream ended; restarting capture loop")
+                await telemetry.cycle_completed(attempt, "stream_end")
+            except asyncio.CancelledError:
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelled():
+                    raise
+                logger.warning(
+                    "ASR capture loop cancelled unexpectedly on attempt %d; retrying",
+                    attempt,
+                    exc_info=True,
+                )
+                await telemetry.cycle_completed(attempt, "cancelled")
+            except Exception as exc:
+                logger.exception("ASR worker capture loop failed: %s", exc)
+                await telemetry.cycle_completed(attempt, "error", detail=type(exc).__name__)
+
+            await asyncio.sleep(current_backoff)
+            backoff = min(current_backoff * 2, 30.0)
     finally:
         await telemetry.aclose()
         await orchestrator.aclose()
 
 
-async def run_worker() -> None:
+async def run_worker(config: ASRConfig | None = None) -> None:
     """Backward-compatible entry point for existing callers/tests."""
 
-    await run()
+    await run(config)
 
 
 def main() -> None:

--- a/kitsu-vtuber-ai/apps/asr_worker/vad.py
+++ b/kitsu-vtuber-ai/apps/asr_worker/vad.py
@@ -23,6 +23,8 @@ class WebRtcVadModule(Protocol):
 
 
 class PassthroughVAD:
+    supports_silence_detection = False
+
     def __init__(self, frame_bytes: int) -> None:
         self._frame_bytes = frame_bytes
 


### PR DESCRIPTION
## Summary
- expose the voice activity detector interface from the ASR package for callers and tests
- restore VAD-driven speech detection and legacy process aliasing in the speech pipeline
- reinstate the ASR runner loop with VAD acquisition, telemetry hooks, and exponential backoff handling

## Testing
- pytest kitsu-vtuber-ai/tests/test_asr_worker.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f21e5f6ca4832cada4dfa8471bbb28