### PR TITLE
Fix TTS worker log text length label

### DIFF
--- a/kitsu-vtuber-ai/apps/tts_worker/service.py
+++ b/kitsu-vtuber-ai/apps/tts_worker/service.py
@@ -242,7 +242,7 @@ class TTSService:
         while True:
             job = await self._queue.get()
             logger.debug(
-                "Processando job TTS request_id=%s texto_len=%d voice=%s queue_depth=%d",
+                "Processando job TTS request_id=%s text_len=%d voice=%s queue_depth=%d",
                 job.request_id,
                 len(job.text),
                 job.voice,


### PR DESCRIPTION
## Summary
- update the TTS worker debug log to report `text_len` instead of `texto_len`

## Testing
- poetry run pytest tests/test_telemetry_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68f227dbb218832cae6165343bc414c2