### PR TITLE
Validate Piper env configuration before path conversion

### DIFF
--- a/kitsu-vtuber-ai/apps/tts_worker/service.py
+++ b/kitsu-vtuber-ai/apps/tts_worker/service.py
@@ -127,13 +127,17 @@ class CoquiSynthesizer:
 
 class PiperSynthesizer:
     def __init__(self) -> None:
-        self._binary = Path(os.getenv("PIPER_PATH", "piper"))
-        self._model = Path(os.getenv("PIPER_MODEL", ""))
-        self._config = Path(os.getenv("PIPER_CONFIG", ""))
-        if not self._model:
+        raw_binary = os.getenv("PIPER_PATH", "piper")
+        raw_model = os.getenv("PIPER_MODEL", "")
+
+        if not raw_model or not raw_model.strip():
             raise RuntimeError("PIPER_MODEL is not configured")
-        if not self._binary:
+        if not raw_binary or not raw_binary.strip():
             raise RuntimeError("PIPER_PATH is not configured")
+
+        self._binary = Path(raw_binary)
+        self._model = Path(raw_model)
+        self._config = Path(os.getenv("PIPER_CONFIG", ""))
 
     async def synthesize(
         self, text: str, voice: Optional[str], destination: Path

--- a/kitsu-vtuber-ai/tests/test_tts_worker.py
+++ b/kitsu-vtuber-ai/tests/test_tts_worker.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from apps.tts_worker.service import PiperSynthesizer
+
+
+@pytest.mark.parametrize(
+    "env_var, value, message",
+    [
+        ("PIPER_MODEL", "", "PIPER_MODEL is not configured"),
+        ("PIPER_MODEL", "   ", "PIPER_MODEL is not configured"),
+        ("PIPER_PATH", "", "PIPER_PATH is not configured"),
+        ("PIPER_PATH", "   ", "PIPER_PATH is not configured"),
+    ],
+)
+def test_piper_synthesizer_requires_non_empty_env(monkeypatch, env_var, value, message):
+    """Ensure Piper validates the raw environment values before Path conversion."""
+
+    # provide defaults that pass validation unless overridden by the parametrized case
+    monkeypatch.setenv("PIPER_PATH", os.fspath("/usr/bin/piper"))
+    monkeypatch.setenv("PIPER_MODEL", os.fspath("/models/en_US.onnx"))
+
+    monkeypatch.setenv(env_var, value)
+
+    with pytest.raises(RuntimeError, match=message):
+        PiperSynthesizer()


### PR DESCRIPTION
## Summary
- ensure PiperSynthesizer validates raw PIPER_PATH and PIPER_MODEL values before creating Path objects
- add pytest coverage to assert Piper raises when the environment variables are empty or whitespace

## Testing
- poetry run pytest tests/test_tts_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68f227de0140832c894ab96a48157951