### PR TITLE
Clarify ASR microphone stream device selection

### DIFF
--- a/kitsu-vtuber-ai/apps/asr_worker/audio.py
+++ b/kitsu-vtuber-ai/apps/asr_worker/audio.py
@@ -14,7 +14,11 @@ except ImportError:  # pragma: no cover - handled at runtime
 
 
 class MicrophoneStream:
-    """Captures audio frames from the default microphone using sounddevice."""
+    """Capture audio frames from the configured input device via sounddevice.
+
+    The `RawInputStream` honours :attr:`ASRConfig.input_device` when provided,
+    falling back to the system default microphone when the field is unset.
+    """
 
     def __init__(self, config: ASRConfig) -> None:
         if sd is None:


### PR DESCRIPTION
## Summary
- clarify the MicrophoneStream docstring to document selection of the configured input device or the default microphone
- confirm existing documentation already covers choosing an ASR input device, so no additional changes were required

## Testing
- poetry run ruff check apps/asr_worker/audio.py

------
https://chatgpt.com/codex/tasks/task_e_68f227df28a8832c981c13da3f3d4c17